### PR TITLE
Various fixes including LBC, IAM roles, IGW, and NGW

### DIFF
--- a/modules.tf
+++ b/modules.tf
@@ -28,4 +28,5 @@ module "eks_aws_lb_controller" {
   tags         = var.tags
   oidc         = module.eks_cluster.oidc
   cluster_name = module.eks_cluster.cluster_name
+  vpc_id       = module.eks_network.vpc_id
 }

--- a/modules/aws-load-balancer-controller/helm.tf
+++ b/modules/aws-load-balancer-controller/helm.tf
@@ -19,4 +19,9 @@ resource "helm_release" "eks_helm_controller" {
     name  = "serviceAccount.name"
     value = "aws-load-balancer-controller"
   }
+
+  set {
+    name  = "vpcId"
+    value = var.vpc_id
+  }  
 }

--- a/modules/aws-load-balancer-controller/iam.tf
+++ b/modules/aws-load-balancer-controller/iam.tf
@@ -8,13 +8,13 @@ resource "aws_iam_role" "eks_controller_role" {
         {
             "Effect": "Allow",
             "Principal": {
-                "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/oidc.eks.${data.aws_region.current.name}.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+                "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc}"
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "oidc.eks.${data.aws_region.current.name}.amazonaws.com/id/${local.oidc}:aud": "sts.amazonaws.com",
-                    "oidc.eks.${data.aws_region.current.name}.amazonaws.com/id/${local.oidc}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
+                    "${local.oidc}:aud": "sts.amazonaws.com",
+                    "${local.oidc}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
                 }
             }
         }

--- a/modules/aws-load-balancer-controller/locals.tf
+++ b/modules/aws-load-balancer-controller/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  oidc = split("/", var.oidc)[4]
+  oidc = replace(var.oidc, "https://", "")
 }

--- a/modules/aws-load-balancer-controller/serviceaccount.tf
+++ b/modules/aws-load-balancer-controller/serviceaccount.tf
@@ -6,4 +6,5 @@ resource "kubernetes_service_account" "eks_Controller_sa" {
       "eks.amazonaws.com/role-arn" = aws_iam_role.eks_controller_role.arn
     }
   }
+  automount_service_account_token = true
 }

--- a/modules/aws-load-balancer-controller/variables.tf
+++ b/modules/aws-load-balancer-controller/variables.tf
@@ -17,3 +17,9 @@ variable "cluster_name" {
   type        = string
   description = "Cluster Name"
 }
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID for LBC to use"
+}
+

--- a/modules/managed_node_group/iam.tf
+++ b/modules/managed_node_group/iam.tf
@@ -36,5 +36,5 @@ resource "aws_iam_role_policy_attachment" "eks_mng_role_attachment_ecr" {
 
 resource "aws_iam_role_policy_attachment" "eks_mng_role_attachment_cni" {
   role       = aws_iam_role.eks_mng_role.name
-  policy_arn = "arn:aws:iam::aws:policy/Amazon_CNI_Policy"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
 }

--- a/modules/managed_node_group/mng.tf
+++ b/modules/managed_node_group/mng.tf
@@ -9,7 +9,7 @@ resource "aws_eks_node_group" "eks_managed_node_group" {
 
   scaling_config {
     desired_size = 1
-    max_size     = 1
+    max_size     = 3
     min_size     = 1
   }
 

--- a/modules/network/igw.tf
+++ b/modules/network/igw.tf
@@ -1,5 +1,5 @@
 resource "aws_internet_gateway" "eks_igw" {
-  vpc_id = var.vpc_cidr
+  vpc_id = aws_vpc.eks_vpc.id
   tags = merge(
     var.tags,
     {
@@ -9,7 +9,7 @@ resource "aws_internet_gateway" "eks_igw" {
 }
 
 resource "aws_route_table" "eks_pub_rt" {
-  vpc_id = var.vpc_cidr
+  vpc_id = aws_vpc.eks_vpc.id
 
   route {
     cidr_block = "0.0.0.0/0"

--- a/modules/network/ngw.tf
+++ b/modules/network/ngw.tf
@@ -49,7 +49,7 @@ resource "aws_nat_gateway" "eks_ngw_1b" {
 }
 
 resource "aws_route_table" "eks_priv_rt_1a" {
-  vpc_id = var.vpc_cidr
+  vpc_id = aws_vpc.eks_vpc.id
 
   route {
     cidr_block     = "0.0.0.0/0"
@@ -66,7 +66,7 @@ resource "aws_route_table" "eks_priv_rt_1a" {
 }
 
 resource "aws_route_table" "eks_priv_rt_1b" {
-  vpc_id = var.vpc_cidr
+  vpc_id = aws_vpc.eks_vpc.id
 
   route {
     cidr_block     = "0.0.0.0/0"

--- a/modules/network/output.tf
+++ b/modules/network/output.tf
@@ -13,3 +13,7 @@ output "subnet_priv_1a" {
 output "subnet_priv_1b" {
   value = aws_subnet.eks_subnet_private_1b.id
 }
+
+output "vpc_id" {
+  value = aws_vpc.eks_vpc.id
+}


### PR DESCRIPTION
Hi!

Nice repo.  Here are the things I fixed

1 - LBC nodes where failing because they could not get VPC ID from the EC2 instance metadata, so I am now configuring the VPC ID at creation time
```
{"level":"error","ts":1738900516.728433,"logger":"setup","msg":"unable to initialize AWS cloud","error":"failed to introspect vpcID from EC2Metadata or Node name, specify --aws-vpc-id instead if EC2Metadata is unavailable: failed to fetch VPC ID from instance metadata: EC2MetadataError: failed to make EC2Metadata request\n\n\tstatus code: 401, request id: "}
```
2- load-balancer-controller-role had a typo where a place holder was being used for the OIDC provider
```
Failed build model due to WebIdentityErr: failed to retrieve credentials caused by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity status code: 403, request id: aac0ae81-97ac-42d5-b519-2d45ca59c502
```
3 - eks_mng_role_attachment_cni role was trying to use an out of date IAM policy, so I updated it

4 - Increased the max_size of the Node group from 1 to 3, otherwise it is hard to run anything on it

5 - Replaced where VPC ID should be used instead of VPC CIDR